### PR TITLE
Removing hardcoded logic for dump clips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 .cxx
 local.properties
 app/src/main/res/values/credentials.xml
+asl_venv/
+dump.csv
+dump.json

--- a/server/collector/dump_clips.py
+++ b/server/collector/dump_clips.py
@@ -54,13 +54,13 @@ def get_data(username):
       data = doc_dict.get('data')
       clip_id = data.get('clipId')
       assert clip_id
-      m = re.match(r'[^-]*-s(\d{3})-(\d{3})', clip_id)
+      m = re.match(r'[^-]+-s(\d{3})-(\d{3})', clip_id)
       assert m, clip_id
       session_index = int(m.group(1))
       clip_index = int(m.group(2))
       filename = data.get('filename')
       assert filename
-      m = re.match(r'^(tutorial-)?(.*[^-]+)-[^-]*-s(\d{3})-.*\.mp4$', filename) # keep tutorial prefixing -- make sure group indices are correct later
+      m = re.match(r'^(tutorial-)?(.+[^-]+)-[^-]+-s(\d{3})-.+\.mp4$', filename) # keep tutorial prefixing -- make sure group indices are correct later
       assert m, filename
       tutorial_prefix = m.group(1)
       user_id = m.group(2)

--- a/server/collector/dump_clips.py
+++ b/server/collector/dump_clips.py
@@ -36,18 +36,16 @@ assert PROJECT_ID, 'must specify the environment variable GOOGLE_CLOUD_PROJECT'
 BUCKET_NAME = f'{PROJECT_ID}.appspot.com'
 SERVICE_ACCOUNT_EMAIL = f'{PROJECT_ID}@appspot.gserviceaccount.com'
 
-# dqp data collection specific code.
-_SPLIT_DQP00 = True
-# Match these accounts (ignore test accounts).
-_MATCH_USERS = re.compile(r'^dqp\d{2}$')
+# Match these accounts.
+_MATCH_USERS = re.compile(r'^test\d{3}$')
 # stem name of the output files (json and csv).
-_DUMP_ID = 'dqp2024-02-06'
+_DUMP_ID = 'dump'
 
 
 def get_data(username):
   """Obtain the clip and session data from firestore."""
   db = firestore.Client()
-  c_ref = db.collection(f'collector/users/{username}/data/save')
+  c_ref = db.collection(f'collector/users/{username}/data/save_clip')
   clips = list()
   sessions = list()
   for doc_data in c_ref.stream():
@@ -62,18 +60,11 @@ def get_data(username):
       clip_index = int(m.group(2))
       filename = data.get('filename')
       assert filename
-      m = re.match(r'^(tutorial-)?(dqp[^-]+)-[^-]*-s(\d{3})-.*\.mp4$',
-                   filename)
+      m = re.match(r'^(tutorial-)?(.*[^-]+)-[^-]*-s(\d{3})-.*\.mp4$', filename) # keep tutorial prefixing -- make sure group indices are correct later
       assert m, filename
       tutorial_prefix = m.group(1)
       user_id = m.group(2)
       assert session_index == int(m.group(3)), (clip_id, filename)
-      if _SPLIT_DQP00:
-        if user_id == 'dqp00':
-          if session_index == 4 or session_index >= 21:
-            user_id = 'dqp00_1'
-          else:
-            user_id = 'dqp00_2'
 
       simple_clip = {
           'userId': user_id,

--- a/server/collector/dump_clips.py
+++ b/server/collector/dump_clips.py
@@ -36,7 +36,7 @@ assert PROJECT_ID, 'must specify the environment variable GOOGLE_CLOUD_PROJECT'
 BUCKET_NAME = f'{PROJECT_ID}.appspot.com'
 SERVICE_ACCOUNT_EMAIL = f'{PROJECT_ID}@appspot.gserviceaccount.com'
 
-# Match these accounts.
+# Match these accounts (with a prefix of test)
 _MATCH_USERS = re.compile(r'^test\d{3}$')
 # stem name of the output files (json and csv).
 _DUMP_ID = 'dump'
@@ -130,6 +130,7 @@ def main():
     if not m:
       continue
     retry = True
+    print(f"Getting data for user: {c_ref.id}")
     while retry:
       retry = False
       try:


### PR DESCRIPTION
## Description
- Updated `dump_clips.py` to not use hardcoded values
- Changed regex patterns to not use wildcards (more efficient)

## Testing
- Successfully generated CSV and JSON files for users in Firestore with expected output
- Verified that output was not affected by removing regex wildcards