### PR TITLE
Making clipping buffers configurable

### DIFF
--- a/server/collector/local_video_pipeline.py
+++ b/server/collector/local_video_pipeline.py
@@ -28,6 +28,7 @@ import clip_video
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--clean', action='store_true', default=False, help='Clean all existing files')
+    parser.add_argument('--buffers', type=str, default=None, help='Config file for user buffers')
     args = parser.parse_args()
 
     if args.clean:
@@ -47,4 +48,4 @@ if __name__ == '__main__':
 
     print("\n\nSTARTING VIDEO CLIPPING")
     print("---------------------------------------")
-    clip_video.main()
+    clip_video.main(args.buffers)


### PR DESCRIPTION
# Description
Made it possible to configure clipping start and end buffers for different users. Default will continue to be 0.5 seconds

# Testing
1. `cd server/collector`
2. Create `buffers.json` file with following content: ```{
    "test006": {
        "start": 1,
        "end": 1.5
    }
}```
3. Run `python local_video_pipeline.py --clean --buffers buffers.json` 