### PR TITLE
Echoi null prompts2

### DIFF
--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
@@ -160,10 +160,6 @@ class HomeScreenActivity : ComponentActivity() {
     }
 
   private fun updateConnectionUi(isConnected: Boolean) {
-    // TODO When reloading the app, this will generally run before dataManager.runDirectives
-    // runs. This means, that the data will be incorrect and won't be reloaded until
-    // the upload now button is pressed or the app is restarted. The best way to fix this
-    // would be to have dataManager broadcast a message every time the server is pinged.
     Log.d(TAG, "Updating UI with connection status: $isConnected")
     val connectivityManager =
       applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -312,118 +308,141 @@ class HomeScreenActivity : ComponentActivity() {
 
       startRecordingButton.setOnTouchListener(::hapticFeedbackOnTouchListener)
       startRecordingButton.setOnClickListener {
-        fun checkPermission(perm: String): Boolean {
-          return ContextCompat.checkSelfPermission(applicationContext, perm) ==
-              PackageManager.PERMISSION_GRANTED
-        }
-
-        fun shouldAsk(perm: String): Boolean {
-          return shouldShowRequestPermissionRationale(perm)
-        }
-
-        fun cannotGetPermission(perm: String): Boolean {
-          return !checkPermission(perm) && !shouldAsk(perm)
-        }
-
-        Log.d(TAG, "Camera allowed: ${checkPermission(CAMERA)}")
-        Log.d(TAG, "Ask for camera permission: ${shouldAsk(CAMERA)}")
-
-        if (checkPermission(CAMERA)) {
-          lifecycleScope.launch {
-            // You can use the API that requires the permission.
-            val intent = Intent(
-              this@HomeScreenActivity, RecordingActivity::class.java
-            ).also {
-              it.putExtra("SEND_CONFIRMATION_EMAIL", emailing)
-            }
-            UploadService.pauseUploadTimeout(UploadService.UPLOAD_RESUME_ON_IDLE_TIMEOUT)
-            Log.d(TAG, "Pausing uploads and waiting for data lock to be available.")
-            dataManager.waitForDataLock()
-            Log.d(TAG, "Data lock was available.")
-
-            handleRecordingResult.launch(intent)
-          }
-        } else if (!permissionRequestedPreviously) {
-          // No permissions, and we haven't asked for permissions before
-          permissionRequestedPreviously = true
-          CoroutineScope(Dispatchers.IO).launch {
-            val keyObject = booleanPreferencesKey("permissionRequestedPreviously")
-            applicationContext.prefStore.edit {
-              it[keyObject] = true
-            }
-          }
-          requestRecordingPermissions.launch(arrayOf(CAMERA))
-        } else if (permissionRequestedPreviously && shouldAsk(CAMERA)) {
-          // We've asked the user for permissions before, and the prior `when` case failed,
-          // so we are allowed to ask for at least one of the required permissions
-
-          // Send an alert prompting the user that they need to grant permissions
-          val builder = AlertDialog.Builder(applicationContext).apply {
-            setTitle(getString(R.string.perm_alert))
-            setMessage(getString(R.string.perm_alert_message))
-
-            setPositiveButton(getString(R.string.ok)) { dialog, _ ->
-              requestRecordingPermissions.launch(
-                arrayOf(CAMERA)
-              )
-              dialog.dismiss()
-            }
-          }
-
-          val dialog = builder.create()
-          dialog.apply {
-            setCanceledOnTouchOutside(true)
-            setOnCancelListener {
-              requestRecordingPermissions.launch(
-                arrayOf(CAMERA)
-              )
-            }
-            show()
-          }
-        } else if (permissionRequestedPreviously && cannotGetPermission(CAMERA)) {
-          // We've asked the user for permissions before, they haven't been granted,
-          // and we cannot ask the user for either camera or storage permissions (we already
-          // asked them before)
-          val text = "Please enable camera access in Settings"
-          val toast = Toast.makeText(applicationContext, text, Toast.LENGTH_LONG)
-          toast.show()
+        if (prompts == null) {
+          AlertDialog.Builder(this@HomeScreenActivity)
+            .setTitle("No Prompts Available")
+            .setMessage("No prompts have been assigned. Please assign prompts before starting.")
+            .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
+            .show()
         } else {
-          Log.e(TAG, "Invalid permission state.")
-          val text =
-            "The app is in a bad state, you likely need to enable camera access in Settings."
-          val toast = Toast.makeText(applicationContext, text, Toast.LENGTH_LONG)
-          toast.show()
+
+          fun checkPermission(perm: String): Boolean {
+            return ContextCompat.checkSelfPermission(applicationContext, perm) ==
+                PackageManager.PERMISSION_GRANTED
+          }
+
+          fun shouldAsk(perm: String): Boolean {
+            return shouldShowRequestPermissionRationale(perm)
+          }
+
+          fun cannotGetPermission(perm: String): Boolean {
+            return !checkPermission(perm) && !shouldAsk(perm)
+          }
+
+          Log.d(TAG, "Camera allowed: ${checkPermission(CAMERA)}")
+          Log.d(TAG, "Ask for camera permission: ${shouldAsk(CAMERA)}")
+
+          if (checkPermission(CAMERA)) {
+            lifecycleScope.launch {
+              // You can use the API that requires the permission.
+              val intent = Intent(
+                this@HomeScreenActivity, RecordingActivity::class.java
+              ).also {
+                it.putExtra("SEND_CONFIRMATION_EMAIL", emailing)
+              }
+              UploadService.pauseUploadTimeout(UploadService.UPLOAD_RESUME_ON_IDLE_TIMEOUT)
+              Log.d(TAG, "Pausing uploads and waiting for data lock to be available.")
+              dataManager.waitForDataLock()
+              Log.d(TAG, "Data lock was available.")
+
+              handleRecordingResult.launch(intent)
+            }
+          } else if (!permissionRequestedPreviously) {
+            // No permissions, and we haven't asked for permissions before
+            permissionRequestedPreviously = true
+            CoroutineScope(Dispatchers.IO).launch {
+              val keyObject = booleanPreferencesKey("permissionRequestedPreviously")
+              applicationContext.prefStore.edit {
+                it[keyObject] = true
+              }
+            }
+            requestRecordingPermissions.launch(arrayOf(CAMERA))
+          } else if (permissionRequestedPreviously && shouldAsk(CAMERA)) {
+            // We've asked the user for permissions before, and the prior `when` case failed,
+            // so we are allowed to ask for at least one of the required permissions
+
+            // Send an alert prompting the user that they need to grant permissions
+            val builder = AlertDialog.Builder(applicationContext).apply {
+              setTitle("Permissions are required to use the app")
+              setMessage(
+                "In order to record your data, we will need access to " +
+                    "the camera and write functionality."
+              )
+
+              setPositiveButton("OK") { dialog, _ ->
+                requestRecordingPermissions.launch(
+                  arrayOf(CAMERA)
+                )
+                dialog.dismiss()
+              }
+            }
+
+            val dialog = builder.create()
+            dialog.apply {
+              setCanceledOnTouchOutside(true)
+              setOnCancelListener {
+                requestRecordingPermissions.launch(
+                  arrayOf(CAMERA)
+                )
+              }
+              show()
+            }
+          } else if (permissionRequestedPreviously && cannotGetPermission(CAMERA)) {
+            // We've asked the user for permissions before, they haven't been granted,
+            // and we cannot ask the user for either camera or storage permissions (we already
+            // asked them before)
+            val text = "Please enable camera access in Settings"
+            val toast = Toast.makeText(applicationContext, text, Toast.LENGTH_LONG)
+            toast.show()
+          } else {
+            Log.e(TAG, "Invalid permission state.")
+            val text =
+              "The app is in a bad state, you likely need to enable camera access in Settings."
+            val toast = Toast.makeText(applicationContext, text, Toast.LENGTH_LONG)
+            toast.show()
+          }
         }
       } // setRecordingButton.onClickListener
 
       val uploadButton = findViewById<Button>(R.id.uploadButton)
       uploadButton.setOnTouchListener(::hapticFeedbackOnTouchListener)
       uploadButton.setOnClickListener {
+
         // Show a confirmation dialog before proceeding with the upload
         val builder = AlertDialog.Builder(this@HomeScreenActivity).apply {
-          setTitle(getString(R.string.upload_alert))
-          setMessage(getString(R.string.upload_alert_message))
 
-          setPositiveButton(getString(R.string.yes)) { dialog, _ ->
-            // User confirmed, proceed with the upload
-            Log.i(TAG, "User confirmed upload.")
-            dialog.dismiss()
 
-            // Disable the button and start the upload process
-            Log.i(TAG, "Upload Now button clicked.")
-            uploadButton.isEnabled = false
-            uploadButton.isClickable = false
-            uploadButton.text = getString(R.string.upload_successful)
+          // check if connected to server before uploading
+          if (!dataManager.connectedToServer()) {
+            setTitle("Connection Error:")
+            setMessage("Please check your internet connection or try reconnecting to the server. If the issue persists, consider restarting the app or checking your network settings.")
+            setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
+            show()
+          }
+          else {
+            setTitle(getString(R.string.upload_alert))
+            setMessage(getString(R.string.upload_alert_message))
 
-            // Progress bar appears after confirming
-            val uploadProgressBar = findViewById<ProgressBar>(R.id.uploadProgressBar)
-            uploadProgressBar.visibility = View.VISIBLE
-            uploadProgressBar.progress = 0
+            setPositiveButton(getString(R.string.yes)) { dialog, _ ->
+              // User confirmed, proceed with the upload
+              Log.i(TAG, "User confirmed upload.")
+              dialog.dismiss()
 
-            CoroutineScope(Dispatchers.IO).launch {
-              UploadService.pauseUploadUntil(null)
-              try {
-                updateConnectionUi(dataManager.connectedToServer())
+              // Disable the button and start the upload process
+              Log.i(TAG, "Upload Now button clicked.")
+              uploadButton.isEnabled = false
+              uploadButton.isClickable = false
+              uploadButton.text = getString(R.string.upload_successful)
+
+              // Progress bar appears after confirming
+              val uploadProgressBar = findViewById<ProgressBar>(R.id.uploadProgressBar)
+              uploadProgressBar.visibility = View.VISIBLE
+              uploadProgressBar.progress = 0
+
+              CoroutineScope(Dispatchers.IO).launch {
+                UploadService.pauseUploadUntil(null)
+                try {
+                  updateConnectionUi(dataManager.connectedToServer())
 
                 val uploadSucceeded = dataManager.uploadData { progress ->
                   runOnUiThread {
@@ -442,6 +461,9 @@ class HomeScreenActivity : ComponentActivity() {
                     val textFinish = "Upload Failed"
                     val toastFinish = Toast.makeText(applicationContext, textFinish, Toast.LENGTH_LONG)
                     toastFinish.show()
+                    uploadButton.isEnabled = true
+                    uploadButton.isClickable = true
+                    uploadButton.text = "Upload Now"
                   }
                 }
               } catch (e: InterruptedUploadException) {
@@ -454,8 +476,14 @@ class HomeScreenActivity : ComponentActivity() {
                   uploadButton.isClickable = true
                   uploadButton.text = getString(R.string.upload_button)
                 }
+                updateConnectionUi(dataManager.connectedToServer())
               }
-              updateConnectionUi(dataManager.connectedToServer())
+            }
+            updateConnectionUi(dataManager.connectedToServer())
+
+            setNegativeButton("No") { dialog, _ ->
+              Log.i(TAG, "User canceled upload.")
+              dialog.dismiss()
             }
           }
           updateConnectionUi(dataManager.connectedToServer())
@@ -466,6 +494,7 @@ class HomeScreenActivity : ComponentActivity() {
           }
         }
 
+        }
         // Pop up dismissed when clicking outside of it
         val dialog = builder.create()
         dialog.apply {
@@ -586,7 +615,7 @@ class HomeScreenActivity : ComponentActivity() {
       runBlocking {
         username = dataManager.getUsername()
         prompts = dataManager.getPrompts()
-        if (username == null || prompts == null) {
+        if (username == null) {
           val intent = Intent(applicationContext, LoadDataActivity::class.java)
           startActivity(intent)
         }

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
@@ -237,16 +237,16 @@ class HomeScreenActivity : ComponentActivity() {
       loadingText.visibility = View.GONE
       val mainGroup = findViewById<Group>(R.id.mainGroup)
       mainGroup.visibility = View.VISIBLE
-      updateConnectionUi(dataManager.connectedToServer())
       val startRecordingButton = findViewById<Button>(R.id.startButton)
 //      val exitTutorialModeButton = findViewById<Button>(R.id.exitTutorialModeButton)
       val tutorialModeText = findViewById<TextView>(R.id.tutorialModeText)
 //      exitTutorialModeButton.visibility = View.GONE
 
-      //updateConnectionUi()
-      val deviceIdBox = findViewById<TextView>(R.id.deviceIdBox)
-      deviceIdBox.text = deviceId!!
+      Log.d(TAG, "updateConnectionUi call")
+      updateConnectionUi(dataManager.connectedToServer())
 
+      val deviceIdBox= findViewById<TextView>(R.id.deviceIdBox)
+      deviceIdBox.text = deviceId
       if (username != null) {
         val usernameBox = findViewById<TextView>(R.id.usernameBox)
         usernameBox.text = username

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
@@ -24,7 +24,6 @@
 package edu.gatech.ccg.recordthesehands.splash
 
 import android.Manifest.permission.CAMERA
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -165,7 +164,7 @@ class HomeScreenActivity : ComponentActivity() {
     // runs. This means, that the data will be incorrect and won't be reloaded until
     // the upload now button is pressed or the app is restarted. The best way to fix this
     // would be to have dataManager broadcast a message every time the server is pinged.
-    Log.i(TAG, "Updating UI with connection status: $isConnected")
+    Log.d(TAG, "Updating UI with connection status: $isConnected")
     val connectivityManager =
       applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
     val network = connectivityManager.activeNetwork
@@ -238,7 +237,7 @@ class HomeScreenActivity : ComponentActivity() {
       loadingText.visibility = View.GONE
       val mainGroup = findViewById<Group>(R.id.mainGroup)
       mainGroup.visibility = View.VISIBLE
-
+      updateConnectionUi(dataManager.connectedToServer())
       val startRecordingButton = findViewById<Button>(R.id.startButton)
 //      val exitTutorialModeButton = findViewById<Button>(R.id.exitTutorialModeButton)
       val tutorialModeText = findViewById<TextView>(R.id.tutorialModeText)
@@ -504,7 +503,8 @@ class HomeScreenActivity : ComponentActivity() {
 
     // Observe the connectionStatus(for server) LiveData using Observer
     val serverObserver = Observer<Boolean> { isConnected ->
-      Log.i(TAG, "LiveData connection observed: $isConnected")
+      Log.d(TAG, "LiveData connection observed: $isConnected")
+      Log.d(TAG, "Activity lifecycle state: ${lifecycle.currentState}")
       updateConnectionUi(isConnected)
     }
     dataManager.serverStatus.observe(this, serverObserver)

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
@@ -253,10 +253,15 @@ class HomeScreenActivity : ComponentActivity() {
       } else {
         tutorialModeText.visibility = View.GONE
       }
+
       val numPrompts = prompts?.array?.size
       val promptIndex = prompts?.promptIndex
 
-      if (prompts != null && username != null) {
+      if (prompts == null) {
+        startRecordingButton.isEnabled = true
+        startRecordingButton.isClickable = true
+        startRecordingButton.text = "Cannot Start"
+      } else if (prompts != null && username != null) {
         if (promptIndex!! < numPrompts!!) {
           startRecordingButton.isEnabled = true
           startRecordingButton.isClickable = true
@@ -311,7 +316,7 @@ class HomeScreenActivity : ComponentActivity() {
         if (prompts == null) {
           AlertDialog.Builder(this@HomeScreenActivity)
             .setTitle("No Prompts Available")
-            .setMessage("No prompts have been assigned. Please assign prompts before starting.")
+            .setMessage("No prompts have been downloaded. Please download prompts before starting.")
             .setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
             .show()
         } else {

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
@@ -309,11 +309,20 @@ class HomeScreenActivity : ComponentActivity() {
 //            }
 //          }
 //        }
+      } else {
+        val promptsProgressBox = findViewById<TextView>(R.id.completedAndTotalPromptsText)
+        promptsProgressBox.text = getString(R.string.ratio, "0", "0")
+        prompts = dataManager.getPrompts()
+        if (prompts == null) {
+          Log.w(TAG, "Prompts is still null")
+        }
       }
 
       startRecordingButton.setOnTouchListener(::hapticFeedbackOnTouchListener)
       startRecordingButton.setOnClickListener {
         if (prompts == null) {
+          val promptsProgressBox = findViewById<TextView>(R.id.completedAndTotalPromptsText)
+          promptsProgressBox.text = getString(R.string.ratio, "0", "0")
           AlertDialog.Builder(this@HomeScreenActivity)
             .setTitle("No Prompts Available")
             .setMessage("No prompts have been downloaded. Please download prompts before starting.")
@@ -619,9 +628,15 @@ class HomeScreenActivity : ComponentActivity() {
       runBlocking {
         username = dataManager.getUsername()
         prompts = dataManager.getPrompts()
+
+
         if (username == null) {
           val intent = Intent(applicationContext, LoadDataActivity::class.java)
           startActivity(intent)
+        }
+
+        if (prompts == null) {
+          Log.w(TAG, "Prompts is null")
         }
         deviceId = dataManager.getDeviceId()
         val numPrompts = prompts?.array?.size
@@ -630,7 +645,10 @@ class HomeScreenActivity : ComponentActivity() {
           "Started Application phoneId=${deviceId} username=${username} promptIndex=${promptIndex} numPrompts=${numPrompts}"
         )
 
-        setupUI()
+        //setupUI()
+        runOnUiThread {
+          setupUI()
+        }
       }
     }
   }

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/HomeScreenActivity.kt
@@ -253,9 +253,9 @@ class HomeScreenActivity : ComponentActivity() {
       } else {
         tutorialModeText.visibility = View.GONE
       }
-
       val numPrompts = prompts?.array?.size
       val promptIndex = prompts?.promptIndex
+
       if (prompts != null && username != null) {
         if (promptIndex!! < numPrompts!!) {
           startRecordingButton.isEnabled = true
@@ -417,7 +417,6 @@ class HomeScreenActivity : ComponentActivity() {
             setTitle("Connection Error:")
             setMessage("Please check your internet connection or try reconnecting to the server. If the issue persists, consider restarting the app or checking your network settings.")
             setPositiveButton("OK") { dialog, _ -> dialog.dismiss() }
-            show()
           }
           else {
             setTitle(getString(R.string.upload_alert))

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/PromptSelectActivity.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/splash/PromptSelectActivity.kt
@@ -38,10 +38,6 @@ class PromptSelectActivity : ComponentActivity() {
       backArrow.setOnClickListener {
         CoroutineScope(Dispatchers.IO).launch {
           dataManager.setTutorialMode(false)
-          dataManager.getPrompts()?.also {
-            it.promptIndex = 0
-            it.savePromptIndex()
-          }
 
           // startActivity is configured so that it will not run on anything but the main thread. So, this will create the intent and start it on the main thread.
           withContext(Dispatchers.Main) {
@@ -60,10 +56,6 @@ class PromptSelectActivity : ComponentActivity() {
       loadedPrompts.setOnClickListener {
         CoroutineScope(Dispatchers.IO).launch {
             dataManager.setTutorialMode(false)
-            dataManager.getPrompts()?.also {
-              it.promptIndex = 0
-              it.savePromptIndex()
-          }
           withContext(Dispatchers.Main) {
             val intent = Intent(this@PromptSelectActivity, HomeScreenActivity::class.java)
             startActivity(intent)
@@ -78,10 +70,6 @@ class PromptSelectActivity : ComponentActivity() {
       tutorialPrompts.setOnClickListener {
         CoroutineScope(Dispatchers.IO).launch {
           dataManager.setTutorialMode(true)
-          dataManager.getPrompts()?.also {
-            it.promptIndex = 0
-            it.savePromptIndex()
-          }
           withContext(Dispatchers.Main) {
             val intent = Intent(this@PromptSelectActivity, HomeScreenActivity::class.java)
             startActivity(intent)

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/upload/DataManager.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/upload/DataManager.kt
@@ -1773,8 +1773,6 @@ class DataManager(val context: Context) {
   /**
    * Check server connection by pinging server
    * method must be called whenever you want to check the server status
-   * TODO: Should the method be looped every so often or be manually called each time whenever the server is accessed?
-   * Right now it is only being called in runDirectives()
    */
   fun checkServerConnection() {
     CoroutineScope(Dispatchers.IO).launch {

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/upload/DataManager.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/upload/DataManager.kt
@@ -1632,6 +1632,7 @@ class DataManager(val context: Context) {
   }
 
   suspend fun getPrompts(): Prompts? {
+    Log.d(TAG, "getPrompts() called")
     val tutorialMode = getTutorialMode()
     if (tutorialMode) {
       return getTutorialPrompts()
@@ -1650,10 +1651,17 @@ class DataManager(val context: Context) {
       }
       val newPromptsData = Prompts(
           context, "tutorialPromptsFilename", "promptIndex")
-      if (!newPromptsData.initialize()) {
+      val initialized = newPromptsData.initialize()
+      Log.d(TAG, "Tutorial prompts initialized: $initialized")
+
+      if (!initialized) {
         return null
       }
-      if (!ensureResources(newPromptsData)) {
+
+      val resourcesEnsured = ensureResources(newPromptsData)
+      Log.d(TAG, "Tutorial prompt resources ensured: $resourcesEnsured")
+
+      if (!resourcesEnsured) {
         return null
       }
       dataManagerData.tutorialPromptsData = newPromptsData
@@ -1845,6 +1853,7 @@ class Prompts(val context: Context, val promptsFilenameKey: String, val promptIn
     }.firstOrNull() ?: return false
     val promptsRelativePath = promptsData.first ?: return false
     promptIndex = promptsData.second ?: return false
+    Log.d(TAG, "Prefs: path=$promptsRelativePath, index=$promptIndex")
     try {
       val promptsJson = JSONObject(File(context.filesDir, promptsRelativePath).readText())
       val promptsJsonArray = promptsJson.getJSONArray("prompts")

--- a/app/src/main/java/edu/gatech/ccg/recordthesehands/upload/DataManager.kt
+++ b/app/src/main/java/edu/gatech/ccg/recordthesehands/upload/DataManager.kt
@@ -1781,7 +1781,7 @@ class DataManager(val context: Context) {
       val isConnected = pingServer()
       _serverStatus.postValue(isConnected) // Update LiveData on the main thread
       // Debugging
-      Log.i(TAG,"Check server connection: $isConnected")
+      Log.d(TAG,"Check server connection: $isConnected")
     }
 
   }


### PR DESCRIPTION
** Issues:**
- Server connectivity not accurate during initial ui setup
- Redirect to login if there were no prompts downloaded
- Uploading available even if disconnected from server
** Fixes **
- Use Livedata in order to update ui correctly at start
- Allow users to go to prompt home activity screen even if no prompts downloaded
- When no prompts have been downloaded "Cannot Start" button appears and warning about no prompt issue shows up when clicking on button
- Show warning popup when user clicks upload now when disconnected from server/internet
**Remaining Issues:**
- Slow update for connectivity (takes a while for the warning about connectivity to change to upload confirmation popup)
- Not really checking internet connectivity (only focused on server connectivity)

Cherry-picked commits from echoi-nullPrompts to allow for easier merging.

Added some sanity checking for null prompts